### PR TITLE
Ensure MongoDB connection is ready before handling requests

### DIFF
--- a/backend/db/connectDB.js
+++ b/backend/db/connectDB.js
@@ -1,12 +1,33 @@
 import mongoose from "mongoose";
 
+const cached = globalThis.mongooseConnection ?? {
+        conn: null,
+        promise: null,
+};
+
 export const connectDB = async () => {
-	try {
-		console.log("mongo_uri: ", process.env.MONGO_URI);
-		const conn = await mongoose.connect(process.env.MONGO_URI);
-		console.log(`MongoDB Connected: ${conn.connection.host}`);
-	} catch (error) {
-		console.log("Error connection to MongoDB: ", error.message);
-		process.exit(1); // 1 is failure, 0 status code is success
-	}
+        if (cached.conn) {
+                return cached.conn;
+        }
+
+        if (!process.env.MONGO_URI) {
+                throw new Error("MONGO_URI environment variable is not defined");
+        }
+
+        if (!cached.promise) {
+                cached.promise = mongoose.connect(process.env.MONGO_URI, {
+                        bufferCommands: false,
+                });
+        }
+
+        try {
+                cached.conn = await cached.promise;
+                console.log(`MongoDB Connected: ${cached.conn.connection.host}`);
+                globalThis.mongooseConnection = cached;
+                return cached.conn;
+        } catch (error) {
+                cached.promise = null;
+                console.error("Error connecting to MongoDB:", error.message);
+                throw error;
+        }
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -24,6 +24,15 @@ app.use(cors(corsOptions));
 app.use(express.json()); // allows us to parse incoming requests:req.body
 app.use(cookieParser()); // allows us to parse incoming cookies
 
+app.use(async (req, res, next) => {
+        try {
+                await connectDB();
+                next();
+        } catch (error) {
+                next(error);
+        }
+});
+
 app.use("/api/auth", authRoutes);
 app.use("/api/users", userRoutes);
 app.use("/api/business", businessRoutes);
@@ -39,7 +48,15 @@ app.use(errorHandler);
 // 	});
 // }
 
-app.listen(PORT, "0.0.0.0", () => {
-	connectDB();
-	console.log("Server is running on port: ", PORT);
-});
+const startServer = async () => {
+        try {
+                await connectDB();
+                app.listen(PORT, "0.0.0.0", () => {
+                        console.log("Server is running on port: ", PORT);
+                });
+        } catch (error) {
+                console.error("Failed to start the server:", error.message);
+        }
+};
+
+startServer();


### PR DESCRIPTION
## Summary
- cache the MongoDB connection in `connectDB` so deployments reuse a single client and fail fast when the URI is missing
- wait for the database connection before starting the server and add middleware to guarantee a connection for every request

## Testing
- npm --prefix backend run start *(fails: missing APPWRITE env vars in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee4179d0b08320892c5cbf073a8577