### PR TITLE
Improve profile editing and integrate business auth

### DIFF
--- a/frontend/api/client.ts
+++ b/frontend/api/client.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError } from 'axios';
+import { getApiBaseUrl } from '@/lib/config';
 
-export const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+export const API_URL = getApiBaseUrl();
 
 const client = axios.create({
   baseURL: API_URL,

--- a/frontend/api/services/business-auth.ts
+++ b/frontend/api/services/business-auth.ts
@@ -1,0 +1,69 @@
+import axios from "axios"
+
+import client from "@/api/client"
+import { useBusinessStore } from "@/store/business-store"
+import type {
+  BusinessAuthResponse,
+  BusinessLoginPayload,
+  BusinessSignupPayload,
+} from "@/types/business"
+
+const BUSINESS_ENDPOINTS = {
+  signup: "/api/auth/business/signup",
+  login: "/api/auth/business/login",
+}
+
+const persistBusinessSession = (data: BusinessAuthResponse) => {
+  const { setBusiness } = useBusinessStore.getState()
+  setBusiness({
+    business: data.business ?? null,
+    token: data.accessToken ?? null,
+  })
+}
+
+const handleBusinessError = (error: unknown): never => {
+  if (axios.isAxiosError(error)) {
+    const message =
+      (error.response?.data as { message?: string; error?: string })?.message ||
+      (error.response?.data as { message?: string; error?: string })?.error ||
+      error.message ||
+      "Business authentication failed"
+    throw new Error(message)
+  }
+
+  if (error instanceof Error) {
+    throw error
+  }
+
+  throw new Error("An unexpected error occurred")
+}
+
+export const signupBusiness = async (
+  payload: BusinessSignupPayload
+): Promise<BusinessAuthResponse> => {
+  try {
+    const { data } = await client.post<BusinessAuthResponse>(BUSINESS_ENDPOINTS.signup, payload)
+    persistBusinessSession(data)
+    return data
+  } catch (error) {
+    return handleBusinessError(error)
+  }
+}
+
+export const loginBusiness = async (
+  payload: BusinessLoginPayload
+): Promise<BusinessAuthResponse> => {
+  try {
+    const { data } = await client.post<BusinessAuthResponse>(BUSINESS_ENDPOINTS.login, payload)
+    persistBusinessSession(data)
+    return data
+  } catch (error) {
+    return handleBusinessError(error)
+  }
+}
+
+export const logoutBusiness = () => {
+  const { clear } = useBusinessStore.getState()
+  clear()
+}
+

--- a/frontend/api/services/profile.ts
+++ b/frontend/api/services/profile.ts
@@ -1,6 +1,6 @@
 import authClient from '@/api/authClient';
 import { uploadAvatar } from '@/api/services/upload';
-import type { UserProfile, UpdateProfileData, ChangePasswordData, UpdateAvatar } from '@/types/profile';
+import type { UserProfile, UpdateProfileData, ChangePasswordData } from '@/types/profile';
 
 // ✅ Professional error handling for profile services
 const handleProfileError = (error: any) => {
@@ -8,9 +8,11 @@ const handleProfileError = (error: any) => {
   throw new Error(error.message || 'Profile operation failed');
 };
 
-export const fetchUserProfile = async (): Promise<UserProfile> => {
+export const fetchUserProfile = async (options?: { signal?: AbortSignal }): Promise<UserProfile> => {
   try {
-    const { data } = await authClient.get('/api/users/me');
+    const { data } = await authClient.get('/api/users/me', {
+      signal: options?.signal,
+    });
     // API may return { user: { ... } } or return the user object directly
     const payload = data?.user ?? data;
     
@@ -40,9 +42,11 @@ export const fetchUserProfile = async (): Promise<UserProfile> => {
 };
 
 // ✅ Fetch updated profile after avatar update
-export const fetchUpdatedProfile = async (): Promise<UserProfile> => {
+export const fetchUpdatedProfile = async (options?: { signal?: AbortSignal }): Promise<UserProfile> => {
   try {
-    const { data } = await authClient.get('/api/users/me');
+    const { data } = await authClient.get('/api/users/me', {
+      signal: options?.signal,
+    });
     
     // API may return { user: { ... } } or return the user object directly
     const payload = data?.user ?? data;

--- a/frontend/api/services/upload.ts
+++ b/frontend/api/services/upload.ts
@@ -22,11 +22,14 @@ const handleUploadError = (error: any) => {
 };
 
 // ✅ Upload file to general folder
-export const uploadFile = async (formData: FormData): Promise<UploadResponse> => {
+export const uploadFile = async (formData: FormData, folder = "general"): Promise<UploadResponse> => {
   try {
-    const { data } = await authClient.post('/api/upload/upload?folder=general', formData, {
+    formData.append("folder", folder)
+
+    const { data } = await authClient.post(`/api/upload/upload?folder=${encodeURIComponent(folder)}`, formData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
+        // Allow browser to attach the correct boundary, only hint the type
+        "Accept": "application/json",
       },
     });
     
@@ -45,6 +48,6 @@ export const uploadFile = async (formData: FormData): Promise<UploadResponse> =>
 export const uploadAvatar = async (file: File): Promise<UploadResponse> => {
   const formData = new FormData();
   formData.append('file', file);
-  
-  return uploadFile(formData);
+
+  return uploadFile(formData, "avatars");
 };

--- a/frontend/app/business/signup/page.tsx
+++ b/frontend/app/business/signup/page.tsx
@@ -1,29 +1,64 @@
 "use client"
 
-import type React from "react"
-
-import { useState } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { ArrowLeft } from "lucide-react"
 import Image from "next/image"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { useCustomToast } from "@/components/custom-toast"
+import { useBusinessSignup } from "@/hooks/business-auth"
+
+const signupSchema = z.object({
+  businessName: z.string().min(2, "Business name is required"),
+  email: z.string().email("Enter a valid email address"),
+  phone: z.string().min(7, "Enter a valid phone number"),
+  password: z.string().min(6, "Password must be at least 6 characters"),
+})
+
+type SignupValues = z.infer<typeof signupSchema>
 
 export default function BusinessSignupPage() {
   const router = useRouter()
-  const [formData, setFormData] = useState({
-    businessName: "",
-    email: "",
-    phone: "",
-    password: "",
+  const toast = useCustomToast()
+  const signupMutation = useBusinessSignup()
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<SignupValues>({
+    resolver: zodResolver(signupSchema),
+    defaultValues: {
+      businessName: "",
+      email: "",
+      phone: "",
+      password: "",
+    },
   })
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    router.push("/business/onboarding")
+  const onSubmit = async (values: SignupValues) => {
+    try {
+      await signupMutation.mutateAsync({
+        name: values.businessName.trim(),
+        email: values.email.trim(),
+        password: values.password,
+        phoneNumber: values.phone.replace(/\s+/g, ""),
+      })
+
+      toast.success("Account created", "Check your email to verify your business account")
+      router.push("/business/onboarding")
+    } catch (error: any) {
+      toast.error("Sign up failed", error?.message ?? "Unable to create account. Please try again.")
+    }
   }
+
+  const isLoading = signupMutation.isPending || isSubmitting
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
@@ -41,29 +76,25 @@ export default function BusinessSignupPage() {
               <p className="text-sm text-gray-600 text-center mt-2">Start reducing waste and earning revenue today</p>
             </div>
 
-            <form onSubmit={handleSubmit} className="space-y-4">
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
               <div>
                 <Label htmlFor="businessName">Business name</Label>
                 <Input
                   id="businessName"
                   type="text"
                   placeholder="Your restaurant or store name"
-                  value={formData.businessName}
-                  onChange={(e) => setFormData({ ...formData, businessName: e.target.value })}
-                  required
+                  autoComplete="organization"
+                  {...register("businessName")}
                 />
+                {errors.businessName?.message ? (
+                  <p className="text-xs text-red-500 mt-1">{errors.businessName.message}</p>
+                ) : null}
               </div>
 
               <div>
                 <Label htmlFor="email">Email address</Label>
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="business@example.com"
-                  value={formData.email}
-                  onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                  required
-                />
+                <Input id="email" type="email" placeholder="business@example.com" autoComplete="email" {...register("email")} />
+                {errors.email?.message ? <p className="text-xs text-red-500 mt-1">{errors.email.message}</p> : null}
               </div>
 
               <div>
@@ -72,10 +103,10 @@ export default function BusinessSignupPage() {
                   id="phone"
                   type="tel"
                   placeholder="+998 90 123 45 67"
-                  value={formData.phone}
-                  onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
-                  required
+                  autoComplete="tel"
+                  {...register("phone")}
                 />
+                {errors.phone?.message ? <p className="text-xs text-red-500 mt-1">{errors.phone.message}</p> : null}
               </div>
 
               <div>
@@ -84,14 +115,14 @@ export default function BusinessSignupPage() {
                   id="password"
                   type="password"
                   placeholder="Create a secure password"
-                  value={formData.password}
-                  onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-                  required
+                  autoComplete="new-password"
+                  {...register("password")}
                 />
+                {errors.password?.message ? <p className="text-xs text-red-500 mt-1">{errors.password.message}</p> : null}
               </div>
 
-              <Button type="submit" className="w-full bg-[#00B14F] hover:bg-[#009940]">
-                Create business account
+              <Button type="submit" className="w-full bg-[#00B14F] hover:bg-[#009940]" disabled={isLoading}>
+                {isLoading ? "Creating account..." : "Create business account"}
               </Button>
             </form>
 

--- a/frontend/components/form-field.tsx
+++ b/frontend/components/form-field.tsx
@@ -11,6 +11,8 @@ export function FormField({
   onChange,
   required = false,
   icon,
+  error,
+  disabled,
 }: FormFieldProps) {
   return (
     <div className="space-y-2">
@@ -33,9 +35,17 @@ export function FormField({
           value={value}
           onChange={onChange}
           required={required}
+          disabled={disabled}
           className={`h-12 rounded-lg border-gray-300 ${icon ? "pl-10" : ""}`}
+          aria-invalid={error ? "true" : undefined}
+          aria-describedby={error ? `${id}-error` : undefined}
         />
       </div>
+      {error ? (
+        <p id={`${id}-error`} className="text-xs text-red-500">
+          {error}
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/frontend/components/profile/avatar-uploader.tsx
+++ b/frontend/components/profile/avatar-uploader.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useCallback } from "react"
+import { Camera, User } from "lucide-react"
+import Image from "next/image"
+
+import { cn } from "@/lib/utils"
+
+const isBlobLike = (url?: string | null) => {
+  if (!url) return false
+  return url.startsWith("blob:") || url.startsWith("data:")
+}
+
+type AvatarUploaderProps = {
+  previewUrl?: string | null
+  isUploading?: boolean
+  onPick: () => void
+  disabled?: boolean
+}
+
+export function AvatarUploader({ previewUrl, isUploading, onPick, disabled }: AvatarUploaderProps) {
+  const handleClick = useCallback(() => {
+    if (!disabled) onPick()
+  }, [disabled, onPick])
+
+  return (
+    <div className="flex justify-center mb-8">
+      <div className="relative">
+        <div className="w-32 h-32 rounded-full bg-gray-100 flex items-center justify-center overflow-hidden">
+          {previewUrl ? (
+            isBlobLike(previewUrl) ? (
+              <img src={previewUrl} alt="Profile avatar" className="w-full h-full object-cover" />
+            ) : (
+              <Image
+                src={previewUrl}
+                alt="Profile avatar"
+                fill
+                sizes="128px"
+                className="object-cover"
+                unoptimized
+              />
+            )
+          ) : (
+            <User className="w-16 h-16 text-[#00B14F]" />
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={handleClick}
+          disabled={disabled || isUploading}
+          className={cn(
+            "absolute bottom-0 right-0 w-11 h-11 rounded-full flex items-center justify-center shadow-lg",
+            "bg-[#00B14F] text-white transition hover:bg-[#009940]",
+            (disabled || isUploading) && "opacity-50 cursor-not-allowed"
+          )}
+        >
+          <Camera className="w-5 h-5" />
+        </button>
+      </div>
+    </div>
+  )
+}
+

--- a/frontend/components/profile/avatar.tsx
+++ b/frontend/components/profile/avatar.tsx
@@ -1,22 +1,35 @@
 import Image from "next/image"
 import { User } from "lucide-react"
 
+const isValidRemoteUrl = (src?: string | null) => {
+  if (!src) return false
+  try {
+    const url = new URL(src)
+    return url.protocol === "https:" || url.protocol === "http:"
+  } catch {
+    return false
+  }
+}
+
 export default function ProfileAvatar({
   avatarUrl,
 }: {
   avatarUrl?: string | null
 }) {
+  const canRenderImage = isValidRemoteUrl(avatarUrl)
+
   return (
     <div className="flex justify-center mb-8">
       <div className="relative w-32 h-32 bg-gray-100 rounded-full overflow-hidden flex items-center justify-center">
-        {avatarUrl ? (
+        {canRenderImage && avatarUrl ? (
           <Image
             src={avatarUrl}
-            alt="Profile Avatar"
+            alt="Profile avatar"
             fill
-            priority
-            sizes="(max-width: 768px) 128px, (max-width: 1200px) 128px, 128px"
+            sizes="128px"
             className="object-cover"
+            priority
+            unoptimized
           />
         ) : (
           <User className="w-16 h-16 text-[#00B14F]" />

--- a/frontend/components/profile/edit-profile-form.tsx
+++ b/frontend/components/profile/edit-profile-form.tsx
@@ -1,161 +1,196 @@
 "use client"
 
-import { useState, useRef, useEffect } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
-import { ArrowLeft, Camera, User, Mail, Phone } from "lucide-react"
-import Image from "next/image"
+import { ArrowLeft, Mail, Phone, User } from "lucide-react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { useAppStore } from "@/store/store"
-import { useCustomToast } from "@/components/custom-toast"
 import { FormField } from "@/components/form-field"
-import { useUpdateProfile, useFetchProfile, useUpdateAvatar } from "@/hooks/profile"
-import type { UpdateProfileData } from "@/types/profile"
+import { AvatarUploader } from "@/components/profile/avatar-uploader"
+import { useCustomToast } from "@/components/custom-toast"
+import { useFetchProfile, useUpdateAvatar, useUpdateProfile } from "@/hooks/profile"
+import type { UpdateProfileData, UserProfile } from "@/types/profile"
+
+const profileSchema = z.object({
+  name: z
+    .string({ required_error: "Name is required" })
+    .min(2, "Name should contain at least 2 characters")
+    .max(120, "Name is too long"),
+  email: z
+    .string({ required_error: "Email is required" })
+    .email("Please enter a valid email address"),
+  phone: z
+    .string()
+    .optional()
+    .transform((value) => value?.trim() ?? ""),
+})
+
+type ProfileFormValues = z.infer<typeof profileSchema>
+
+const normalizePhone = (value?: string | null) => value?.replace(/[^0-9]/g, "") ?? ""
+
+const mapProfileToForm = (profile?: UserProfile | null): ProfileFormValues => ({
+  name: profile?.name ?? "",
+  email: profile?.email ?? "",
+  phone: normalizePhone(profile?.phone ?? profile?.phoneNumber),
+})
 
 export default function EditProfileForm() {
   const router = useRouter()
+  const toast = useCustomToast()
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
-  const { user, setUser } = useAppStore()
-  const { data: profile } = useFetchProfile()
+  const { data: profile, isLoading: isProfileLoading } = useFetchProfile()
   const updateProfileMutation = useUpdateProfile()
   const updateAvatarMutation = useUpdateAvatar()
-  const toast = useCustomToast()
 
-  const [formData, setFormData] = useState<UpdateProfileData>({
-    name: "",
-    email: "",
-    phone: "",
-  })
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null)
   const [avatarFile, setAvatarFile] = useState<File | null>(null)
 
-  // ✅ Prefill form from profile data
+  const initialValues = useMemo(() => mapProfileToForm(profile), [profile])
+
+  const form = useForm<ProfileFormValues>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: initialValues,
+    mode: "onBlur",
+  })
+
   useEffect(() => {
-    if (profile) {
-      setFormData({
-        name: profile.name || "",
-        email: profile.email || "",
-        phone: profile.phone || "",
-      })
-      if (profile.avatar?.url) setAvatarPreview(profile.avatar.url)
+    form.reset(initialValues)
+    if (profile?.avatar && typeof profile.avatar === "object") {
+      setAvatarPreview(profile.avatar.url)
+    } else if (typeof profile?.avatar === "string") {
+      setAvatarPreview(profile.avatar)
+    } else {
+      setAvatarPreview(null)
     }
-  }, [profile])
+    setAvatarFile(null)
+  }, [form, initialValues, profile?.avatar])
 
-  // ✅ Handle input changes
-  const handleChange = (field: keyof UpdateProfileData, value: string) => {
-    setFormData((prev) => ({ ...prev, [field]: value }))
+  useEffect(() => {
+    return () => {
+      if (avatarPreview?.startsWith("blob:")) {
+        URL.revokeObjectURL(avatarPreview)
+      }
+    }
+  }, [avatarPreview])
+
+  const onAvatarPick = () => fileInputRef.current?.click()
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    if (!file.type.startsWith("image/")) {
+      toast.error("Unsupported file", "Please upload an image file")
+      return
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error("File too large", "Max file size is 5MB")
+      return
+    }
+
+    if (avatarPreview?.startsWith("blob:")) {
+      URL.revokeObjectURL(avatarPreview)
+    }
+
+    setAvatarFile(file)
+    const previewUrl = URL.createObjectURL(file)
+    setAvatarPreview(previewUrl)
   }
 
-  // ✅ Avatar upload preview and upload
-  const handleAvatarClick = () => fileInputRef.current?.click()
-  // Avatar file selection only
-const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-  const file = e.target.files?.[0];
-  if (file) {
-    setAvatarFile(file);
-    const previewURL = URL.createObjectURL(file);
-    setAvatarPreview(previewURL);
+  const buildPayload = (values: ProfileFormValues): UpdateProfileData => {
+    const payload: UpdateProfileData = {}
+    if (values.name !== profile?.name) payload.name = values.name.trim()
+    if (values.email !== profile?.email) payload.email = values.email.trim()
+
+    const currentPhone = normalizePhone(profile?.phone ?? profile?.phoneNumber)
+    if (values.phone && values.phone !== currentPhone) {
+      payload.phone = values.phone
+    }
+
+    if (!values.phone && currentPhone) {
+      payload.phone = ""
+    }
+
+    return payload
   }
-};
 
+  const onSubmit = form.handleSubmit(async (values) => {
+    const payload = buildPayload(values)
+    const hasAvatarUpdate = !!avatarFile
 
-  // ✅ Save handler using React Query mutation
-  const handleSave = async () => {
+    if (Object.keys(payload).length === 0 && !hasAvatarUpdate) {
+      toast.info("No changes", "Update a field or choose a new photo before saving")
+      return
+    }
+
     try {
-      if (!formData.name?.trim() || !formData.email?.trim()) {
-        toast.error("Validation Error", "Name and Email are required.");
-        return;
+      if (Object.keys(payload).length > 0) {
+        await updateProfileMutation.mutateAsync(payload)
       }
-  
-      // ✅ Update profile data first (name, email, phone)
-      const updatedProfile = await updateProfileMutation.mutateAsync(formData);
-  
-      // ✅ Upload avatar separately if a new file is selected
-      if (avatarFile) {
-        await updateAvatarMutation.mutateAsync(avatarFile);
+
+      if (hasAvatarUpdate && avatarFile) {
+        await updateAvatarMutation.mutateAsync(avatarFile)
       }
-  
-      // ✅ Profile data is automatically saved to localStorage via Zustand store
-      // The hooks handle updating the store with the complete profile data
-  
-      toast.success("Profile Updated", "Your profile has been updated successfully.");
-      router.push("/profile");
-    } catch (err: any) {
-      console.error("Profile update error:", err);
-      toast.error("Update Failed", err.message || "Failed to update profile. Please try again.");
+
+      toast.success("Profile updated", "Your profile changes have been saved")
+      router.push("/profile")
+    } catch (error: any) {
+      console.error("Profile update failed", error)
+      toast.error("Update failed", error?.message ?? "Unable to update profile. Please try again.")
     }
-  };
-  
+  })
+
+  const isSaving =
+    form.formState.isSubmitting ||
+    updateProfileMutation.isPending ||
+    updateAvatarMutation.isPending
+
+  const isDirty = form.formState.isDirty || !!avatarFile
 
   return (
     <div className="min-h-screen bg-white flex flex-col">
-      {/* Header */}
       <div className="sticky top-0 z-30 bg-white px-6 py-4 flex items-center gap-4 border-b border-gray-100 shadow-sm">
         <Button variant="ghost" size="icon" onClick={() => router.back()}>
           <ArrowLeft />
         </Button>
-        <h1 className="text-lg font-semibold">Edit Profile</h1>
+        <h1 className="text-lg font-semibold">Edit profile</h1>
       </div>
 
-      {/* Scrollable Content */}
-      <div className="flex-1 overflow-y-auto px-6 py-8 pb-36">
-        {/* Avatar */}
-        <div className="flex justify-center mb-8">
-          <div className="relative">
-            <div className="w-32 h-32 rounded-full bg-gray-100 flex items-center justify-center overflow-hidden">
-              {avatarPreview ? (
-                <Image
-                  src={avatarPreview}
-                  alt="Avatar Preview"
-                  width={128}
-                  height={128}
-                  className="object-cover w-full h-full"
-                />
-              ) : profile?.avatar?.url ? (
-                <Image
-                  src={profile.avatar.url}
-                  alt="Current Avatar"
-                  width={128}
-                  height={128}
-                  className="object-cover w-full h-full"
-                />
-              ) : (
-                <User className="w-16 h-16 text-[#00B14F]" />
-              )}
-            </div>
+      <form className="flex-1 overflow-y-auto px-6 py-8 pb-36 space-y-8" onSubmit={onSubmit}>
+        <AvatarUploader
+          previewUrl={avatarPreview}
+          isUploading={updateAvatarMutation.isPending}
+          onPick={onAvatarPick}
+          disabled={isProfileLoading}
+        />
 
-            <button
-              type="button"
-              onClick={handleAvatarClick}
-              disabled={updateAvatarMutation.isPending}
-              className="absolute bottom-0 right-0 w-10 h-10 bg-[#00B14F] rounded-full flex items-center justify-center shadow-md hover:bg-[#009940] transition disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              <Camera className="w-5 h-5 text-white" />
-            </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleFileChange}
+          disabled={updateAvatarMutation.isPending}
+        />
 
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              className="hidden"
-              onChange={handleAvatarChange}
-              disabled={updateAvatarMutation.isPending}
-            />
-          </div>
-        </div>
-
-        {/* Form Fields */}
         <div className="space-y-6">
           <FormField
             id="name"
             label="Name"
             type="text"
             placeholder="Enter your name"
-            value={formData.name ?? ""}
-            onChange={(e) => handleChange("name", e.target.value)}
+            value={form.watch("name")}
+            onChange={(event) => form.setValue("name", event.target.value, { shouldDirty: true })}
             icon={<User className="w-4 h-4" />}
+            error={form.formState.errors.name?.message}
           />
 
           <FormField
@@ -163,54 +198,48 @@ const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
             label="Email"
             type="email"
             placeholder="Enter your email"
-            value={formData.email ?? ""}
-            onChange={(e) => handleChange("email", e.target.value)}
-            required
+            value={form.watch("email")}
+            onChange={(event) => form.setValue("email", event.target.value, { shouldDirty: true })}
             icon={<Mail className="w-4 h-4" />}
+            error={form.formState.errors.email?.message}
           />
 
           <div>
-            <Label
-              htmlFor="phone"
-              className="text-sm font-medium text-gray-700 mb-2 block"
-            >
-              Phone Number
+            <Label htmlFor="phone" className="text-sm font-medium text-gray-700 mb-2 block">
+              Phone number
             </Label>
             <div className="flex gap-2">
-              <Input
-                value="+998"
-                className="h-12 rounded-lg border-gray-300 w-24 text-center bg-gray-50"
-                disabled
-              />
+              <Input value="+998" className="h-12 rounded-lg border-gray-300 w-24 text-center bg-gray-50" disabled />
               <div className="flex-1 relative">
                 <Phone className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
                 <Input
                   id="phone"
                   type="tel"
                   placeholder="90 123 45 67"
-                  value={formData.phone ?? ""}
-                  onChange={(e) => handleChange("phone", e.target.value)}
+                  value={form.watch("phone")}
+                  onChange={(event) => form.setValue("phone", normalizePhone(event.target.value), { shouldDirty: true })}
                   className="h-12 rounded-lg border-gray-300 pl-10"
                 />
               </div>
             </div>
-            <p className="text-xs text-gray-500 mt-1">
-              Enter your phone number without the country code (+998)
-            </p>
+            <p className="text-xs text-gray-500 mt-1">Enter your phone number without the country code (+998)</p>
+            {form.formState.errors.phone?.message ? (
+              <p className="text-xs text-red-500 mt-1">{form.formState.errors.phone.message}</p>
+            ) : null}
           </div>
         </div>
-      </div>
 
-      {/* Save Button */}
-      <div className="fixed bottom-0 left-0 right-0 px-6 py-5 bg-white border-t border-gray-100 shadow-lg">
-        <Button
-          onClick={handleSave}
-          disabled={updateProfileMutation.isPending || updateAvatarMutation.isPending}
-          className="w-full h-14 bg-[#00B14F] hover:bg-[#009940] text-white rounded-2xl text-base font-semibold"
-        >
-          {updateProfileMutation.isPending || updateAvatarMutation.isPending ? "Saving..." : "Save Changes"}
-        </Button>
-      </div>
+        <div className="fixed bottom-0 left-0 right-0 px-6 py-5 bg-white border-t border-gray-100 shadow-lg">
+          <Button
+            type="submit"
+            disabled={!isDirty || isSaving}
+            className="w-full h-14 bg-[#00B14F] hover:bg-[#009940] text-white rounded-2xl text-base font-semibold"
+          >
+            {isSaving ? "Saving..." : "Save changes"}
+          </Button>
+        </div>
+      </form>
     </div>
   )
 }
+

--- a/frontend/hooks/business-auth.ts
+++ b/frontend/hooks/business-auth.ts
@@ -1,0 +1,26 @@
+"use client"
+
+import { useMutation } from "@tanstack/react-query"
+
+import {
+  loginBusiness,
+  signupBusiness,
+} from "@/api/services/business-auth"
+import type {
+  BusinessAuthResponse,
+  BusinessLoginPayload,
+  BusinessSignupPayload,
+} from "@/types/business"
+
+export const useBusinessSignup = () => {
+  return useMutation<BusinessAuthResponse, Error, BusinessSignupPayload>({
+    mutationFn: signupBusiness,
+  })
+}
+
+export const useBusinessLogin = () => {
+  return useMutation<BusinessAuthResponse, Error, BusinessLoginPayload>({
+    mutationFn: loginBusiness,
+  })
+}
+

--- a/frontend/hooks/profile.ts
+++ b/frontend/hooks/profile.ts
@@ -54,8 +54,8 @@ export const useFetchProfile = () => {
 
   return useQuery<UserProfile, Error>({
     queryKey: ["profile"],
-    queryFn: async () => {
-      const profile = await fetchUserProfile()
+    queryFn: async ({ signal }) => {
+      const profile = await fetchUserProfile({ signal })
       return normalizeProfile({ ...profile, token: user?.token }) as UserProfile
     },
     enabled: hasHydrated && !!user?.token,

--- a/frontend/lib/config.ts
+++ b/frontend/lib/config.ts
@@ -1,0 +1,27 @@
+const isBrowser = typeof window !== "undefined"
+
+const normalizeUrl = (url: string | undefined | null) => {
+  if (!url) return undefined
+  try {
+    const parsed = new URL(url)
+    return parsed.origin
+  } catch (error) {
+    console.warn("Invalid NEXT_PUBLIC_API_URL provided:", url, error)
+    return undefined
+  }
+}
+
+const cachedBaseUrl = normalizeUrl(process.env.NEXT_PUBLIC_API_URL)
+const devFallback = process.env.NODE_ENV !== "production" ? "http://localhost:3001" : undefined
+
+export const getApiBaseUrl = () => {
+  if (cachedBaseUrl) return cachedBaseUrl
+  if (!isBrowser && devFallback) {
+    return devFallback
+  }
+  if (isBrowser) {
+    return window.location.origin
+  }
+  throw new Error("NEXT_PUBLIC_API_URL is not defined")
+}
+

--- a/frontend/store/business-store.ts
+++ b/frontend/store/business-store.ts
@@ -1,0 +1,36 @@
+"use client"
+
+import { create } from "zustand"
+import { persist } from "zustand/middleware"
+
+import type { BusinessAccount } from "@/types/business"
+
+type BusinessState = {
+  business: BusinessAccount | null
+  token: string | null
+  setBusiness: (payload: { business?: BusinessAccount | null; token?: string | null }) => void
+  clear: () => void
+}
+
+export const useBusinessStore = create<BusinessState>()(
+  persist(
+    (set) => ({
+      business: null,
+      token: null,
+      setBusiness: ({ business, token }) =>
+        set((state) => ({
+          business: business ?? state.business,
+          token: token ?? state.token,
+        })),
+      clear: () => set({ business: null, token: null }),
+    }),
+    {
+      name: "qopchiq-business-store",
+      partialize: (state) => ({ business: state.business, token: state.token }),
+    }
+  )
+)
+
+export const useBusinessToken = () => useBusinessStore((state) => state.token)
+export const useBusinessAccount = () => useBusinessStore((state) => state.business)
+

--- a/frontend/types/business.ts
+++ b/frontend/types/business.ts
@@ -1,0 +1,36 @@
+export interface BusinessAccount {
+  id?: string
+  name: string
+  email: string
+  phoneNumber?: string
+  description?: string
+  address?: string
+  avatar?: string | { id: string; url: string }
+  isVerified?: boolean
+  isApproved?: boolean
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface BusinessAuthResponse {
+  success?: boolean
+  message?: string
+  accessToken?: string
+  business?: BusinessAccount
+}
+
+export interface BusinessSignupPayload {
+  name: string
+  email: string
+  password: string
+  phoneNumber: string
+  description?: string
+  address?: string
+  businessType?: string
+}
+
+export interface BusinessLoginPayload {
+  email: string
+  password: string
+}
+


### PR DESCRIPTION
## Summary
- add a shared API base-url helper and adjust upload requests so avatar uploads use the production storage service
- rebuild the profile edit form with schema validation, a safer avatar uploader, and improved query caching to avoid client-side errors
- wire up business sign-in and sign-up flows to the backend APIs and persist business session data in the frontend store

## Testing
- pnpm exec tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68ee7091b6c48320a6ae074baaeba157