### PR TITLE
Align mobile viewport shell and stabilize uploads

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -4,7 +4,6 @@ dotenv.config();
 import express from "express";
 import cors from "cors";
 import cookieParser from "cookie-parser";
-import path from "path";
 import { corsOptions } from "./config/cors.js";
 import { connectDB } from "./db/connectDB.js";
 
@@ -17,26 +16,23 @@ import uploadRoutes from "./routes/upload.route.js";
 
 const app = express();
 const PORT = process.env.PORT || 5000;
-const __dirname = path.resolve();
-
+app.set("trust proxy", 1);
 app.use(cors(corsOptions));
-
-app.use(express.json()); // allows us to parse incoming requests:req.body
-app.use(cookieParser()); // allows us to parse incoming cookies
-
-app.use(async (req, res, next) => {
-        try {
-                await connectDB();
-                next();
-        } catch (error) {
-                next(error);
-        }
-});
+app.use(express.json({ limit: "10mb" }));
+app.use(express.urlencoded({ extended: true, limit: "10mb" }));
+app.use(cookieParser());
 
 app.use("/api/auth", authRoutes);
 app.use("/api/users", userRoutes);
 app.use("/api/business", businessRoutes);
 app.use("/api/upload", uploadRoutes);
+
+app.get("/api/health", (req, res) => {
+        res.json({
+                status: "ok",
+                uptime: process.uptime(),
+        });
+});
 // Global error handler (eng oxirida)
 app.use(errorHandler);
 

--- a/backend/services/file.service.js
+++ b/backend/services/file.service.js
@@ -1,5 +1,6 @@
 import { Client, Storage, ID } from 'node-appwrite'
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 import FormData from 'form-data'
 import axios from 'axios'
@@ -34,7 +35,7 @@ class FileService {
         throw new Error("Fayl tanlanmadi yoki noto'g'ri formatda")
       }
 
-      const uploadsDir = path.join(process.cwd(), 'uploads')
+      const uploadsDir = path.join(os.tmpdir(), 'qopchiq-upload-cache')
       if (!fs.existsSync(uploadsDir)) {
         await fs.promises.mkdir(uploadsDir, { recursive: true })
       }
@@ -43,7 +44,6 @@ class FileService {
       const filename = `${Date.now()}_${file.originalname}`
       const filePath = path.join(uploadsDir, filename)
 
-      // Vaqtinchalik saqlash
       await fs.promises.writeFile(filePath, file.buffer)
 
       const form = new FormData()
@@ -62,7 +62,7 @@ class FileService {
         }
       )
 
-      await fs.promises.unlink(filePath)
+      await fs.promises.unlink(filePath).catch(() => {})
 
       return {
         success: true,
@@ -74,6 +74,7 @@ class FileService {
         fileUrl: `${process.env.APPWRITE_ENDPOINT}/storage/buckets/${this.bucketId}/files/${data.$id}/view?project=${process.env.APPWRITE_PROJECT_ID}`
       }
     } catch (error) {
+      console.error('File upload failed:', error.message)
       return { success: false, error: error.message }
     }
   }

--- a/backend/services/storage/appwriteStorage.js
+++ b/backend/services/storage/appwriteStorage.js
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 dotenv.config();
 
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { ID } from "node-appwrite";
 import FormData from "form-data";
@@ -29,7 +30,7 @@ export default class AppwriteStorage extends FileStorage {
 		}
 
 		try {
-			const uploadsDir = path.join(process.cwd(), "uploads");
+                        const uploadsDir = path.join(os.tmpdir(), "qopchiq-upload-cache");
 			if (!fs.existsSync(uploadsDir)) {
 				await fs.promises.mkdir(uploadsDir, { recursive: true });
 			}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -29,14 +29,6 @@
   animation: bounce-slow 3s ease-in-out infinite;
 }
 
-/* Hide mobile-only pages on desktop before JS runs */
-@media (min-width: 768px) {
-  html[data-mobile-only="true"] body > *:not(.mobile-warning) {
-    display: none !important;
-  }
-}
-
-
 :root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -5,8 +5,8 @@ import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 import MobileOnlyNotice from "@/components/mobile-banner";
 import BottomNavWrapper from "@/components/bottom-navigation-wrapper";
-import { Toaster } from "@/components/ui/toaster"
-import Providers from './providers'
+import { Toaster } from "@/components/ui/toaster";
+import Providers from "./providers";
 
 export const metadata: Metadata = {
   title: "qopchiq",
@@ -19,14 +19,20 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
-      <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable} min-h-screen bg-white`}>
+      <body
+        className={`font-sans ${GeistSans.variable} ${GeistMono.variable} min-h-screen bg-neutral-100 text-foreground`}
+      >
         <MobileOnlyNotice />
         <Providers>
-          {children}
-          <Toaster />
-          <Analytics />
-          {/* ✅ Wrapper decides when to show the BottomNav */}
-          <BottomNavWrapper />
+          <div className="relative mx-auto flex min-h-screen w-full max-w-md flex-col overflow-hidden bg-white shadow-none md:my-6 md:max-w-lg md:rounded-3xl md:border md:border-gray-200 md:shadow-2xl">
+            <main className="flex-1 overflow-x-hidden pb-24" data-testid="app-shell">
+              {children}
+            </main>
+            <Toaster />
+            <Analytics />
+            {/* ✅ Wrapper decides when to show the BottomNav */}
+            <BottomNavWrapper />
+          </div>
         </Providers>
       </body>
     </html>

--- a/frontend/components/bottom-navigation.tsx
+++ b/frontend/components/bottom-navigation.tsx
@@ -24,8 +24,9 @@ export default function BottomNavigation() {
   ];
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-40 border-t border-gray-100 bg-white shadow-md">
-      <div className="flex items-center justify-around py-2">
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center pb-[env(safe-area-inset-bottom,0px)]">
+      <div className="pointer-events-auto mx-auto mb-3 w-full max-w-md rounded-t-3xl border border-gray-100 bg-white/95 shadow-[0_-10px_30px_rgba(15,23,42,0.08)] backdrop-blur">
+        <div className="flex items-center justify-around px-2 py-2">
         {navItems.map((item) => {
           const Icon = item.icon;
           const isActive = activeTab === item.id;
@@ -34,8 +35,10 @@ export default function BottomNavigation() {
             <button
               key={item.id}
               onClick={() => router.push(item.route)}
-              className={`flex flex-col items-center gap-1 px-4 py-1 transition-colors ${
-                isActive ? "text-[#00B14F]" : "text-gray-400"
+              className={`flex flex-col items-center gap-1 rounded-2xl px-4 py-1 transition-all ${
+                isActive
+                  ? "text-[#00B14F]"
+                  : "text-gray-400 hover:text-gray-600"
               }`}
             >
               <Icon className="w-6 h-6" />
@@ -46,6 +49,7 @@ export default function BottomNavigation() {
             </button>
           );
         })}
+      </div>
       </div>
     </div>
   );

--- a/frontend/components/mobile-banner.tsx
+++ b/frontend/components/mobile-banner.tsx
@@ -1,34 +1,10 @@
 "use client";
 
-import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
-import Image from "next/image";
+import { Smartphone } from "lucide-react";
 
 export default function MobileOnlyNotice() {
-  const pathname = usePathname();
   const [isMobile, setIsMobile] = useState<boolean | null>(null); // null = unknown during SSR
-
-  const mobileOnlyRoutes = [
-    // "/feed",
-    // "/profile",
-    // "/restaurant",
-    // "/profile-setup",
-    // "/settings/location",
-    // "/settings/marketing",
-    // "/settings/notifications",
-    // "/onboarding",
-    // "/signin",
-    // "/signup",
-    // "/licences",
-    // "/ad-address",
-    // "/filter",
-    // "/forgot-password",
-    // "/orders",
-    "/favourites",
-    // "/more",
-  ];
-
-  const shouldShow = mobileOnlyRoutes.some((r) => pathname.startsWith(r));
 
   useEffect(() => {
     // Detect on mount only (prevents flicker)
@@ -38,61 +14,21 @@ export default function MobileOnlyNotice() {
     return () => window.removeEventListener("resize", checkWidth);
   }, []);
 
-  // ⚠️ During SSR or before hydration, hide everything
-  if (isMobile === null) {
-    return (
-      <div className="fixed inset-0 bg-white" aria-hidden="true"></div>
-    );
-  }
+  if (isMobile !== false) return null;
 
-  // if not a mobile-only route → do nothing
-  if (!shouldShow) return null;
-  // if user is already on mobile → show app content
-  if (isMobile) return null;
-
-  // Otherwise, show banner
   return (
-    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center overflow-hidden bg-gradient-to-br from-emerald-600 via-green-600 to-teal-700 text-white text-center px-6">
-      {/* Food emojis */}
-      <div className="absolute inset-0 pointer-events-none select-none opacity-20 text-6xl">
-        <div className="absolute top-6 left-10 animate-bounce">🍕</div>
-        <div className="absolute top-20 right-16 animate-pulse">🥗</div>
-        <div className="absolute bottom-10 left-12 animate-bounce">🍔</div>
-        <div className="absolute bottom-16 right-14 animate-pulse">🍩</div>
-      </div>
-
-      {/* Text */}
-      <div className="relative z-10 mb-6">
-        <h1 className="text-3xl font-bold mb-3 drop-shadow-lg">
-          Mobile View Only 📱
-        </h1>
-        <p className="text-gray-100 max-w-md leading-relaxed">
-          The <span className="font-semibold">Qopchiq</span> app is crafted for
-          mobile experience. <br /> Please open it on your phone or resize your
-          browser below <span className="font-semibold">768px</span>.
-        </p>
-      </div>
-
-      {/* Screenshot mockup */}
-      <div className="relative z-10 mt-4">
-        <div className="rounded-[2.5rem] border-[6px] border-white shadow-2xl overflow-hidden w-[280px] h-[580px] bg-gray-900">
-          <Image
-            src="/phone.png"
-            alt="Qopchiq mobile preview"
-            width={280}
-            height={580}
-            className="object-cover w-full h-full"
-            priority
-          />
+    <div className="mobile-warning pointer-events-none fixed inset-x-0 top-0 z-50 flex justify-center px-4">
+      <div className="pointer-events-auto mt-4 flex w-full max-w-md items-center gap-3 rounded-full bg-emerald-600/95 px-4 py-2 text-sm text-white shadow-lg ring-1 ring-white/40 md:max-w-lg">
+        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-white/15">
+          <Smartphone className="h-5 w-5" aria-hidden="true" />
+        </span>
+        <div className="flex flex-col gap-0">
+          <p className="font-semibold leading-tight">Mobile-sized experience</p>
+          <p className="text-xs leading-tight text-emerald-100">
+            You're viewing Qopchiq in its mobile layout. Resize the window or continue using the touch-optimised UI.
+          </p>
         </div>
       </div>
-
-      <p className="mt-6 text-sm text-gray-200 relative z-10">
-        Experience the best of{" "}
-        <span className="font-bold text-yellow-300">food-saving</span> and{" "}
-        <span className="font-bold text-yellow-300">discount offers</span> on
-        your phone!
-      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- center the application inside a mobile-sized shell so desktop users see the responsive layout, and soften the desktop mobile-warning banner
- restyle the bottom navigation to stay constrained to the shell and adjust global styles to avoid hiding pages on large screens
- harden upload services to use tmp storage suited for Vercel/serverless deployments, add a health endpoint, and remove redundant DB connections for faster boot

## Testing
- npm run lint *(fails: command prompts for ESLint configuration in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68eeb8a059a88320974b1216485741ef